### PR TITLE
Fix links to data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ The Appeal has created the first national database of prison commissary lists. U
 
 The data is split across three files:
 
-- [`data/commissary-lists-20240417.csv`](https://github.com/the-appeal/commissary-data/edit/main/data/commissary-lists-20240417.csv): Links and other metadata for commissary lists from each of the 46 states that provided records.
-- [`data/commissary-summaries-20240417.csv`](https://github.com/the-appeal/commissary-data/edit/main/data/commissary-summaries-20240417.csv): A state-by-state summary of the cost of basic food, hygiene, and other items selected by The Appeal.
-- [`data/commissary-prices-20240417.csv`](https://github.com/the-appeal/commissary-data/edit/main/data/commissary-prices-20240417.csv): Raw price data used in The Appeal’s analysis of 24 different food, hygiene, and religious products.
+- [`data/commissary-lists-20240417.csv`](data/commissary-lists-20240417.csv): Links and other metadata for commissary lists from each of the 46 states that provided records.
+- [`data/commissary-summaries-20240417.csv`](data/commissary-summaries-20240417.csv): A state-by-state summary of the cost of basic food, hygiene, and other items selected by The Appeal.
+- [`data/commissary-prices-20240417.csv`](data/commissary-prices-20240417.csv): Raw price data used in The Appeal’s analysis of 24 different food, hygiene, and religious products.
 
 We will periodically update the data in this repository as we continue to receive new commissary lists and extract data from the lists we have.
 


### PR DESCRIPTION
Hello! I noticed that your data links in the README were linking to the "edit" URLs for the CSV files, which means that if anyone other than the repository owner were to click on them, they would be prompted to fork the repository instead of just viewing the files.

Thus I changed the links to be "view" links (rather than "edit" links), and I also changed them from absolute to relative links, since I think that's more in line with what people would expect (if they were to fork the repository).

Hope this is helpful!